### PR TITLE
Add paragraph statistics and toggle availability logic

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -18,9 +18,10 @@ export const TEXT_CONTENT = Object.freeze({
     IMAGE_PLAIN_TEXT_PLACEHOLDER: "[Image]",
     ERROR_NO_TEXT: "Please enter some text to split.",
     ERROR_INVALID_CUSTOM: "Please enter a valid positive number for custom size.",
-    STATS_TEMPLATE: "Characters: {characters} | Words: {words} | Sentences: {sentences}",
+    INPUT_STATS_TEMPLATE: "Characters: {characters} | Words: {words} | Sentences: {sentences} | Paragraphs: {paragraphs}",
+    CHUNK_STATS_TEMPLATE: "Characters: {characters} | Words: {words} | Sentences: {sentences}",
     ENUMERATION_TEMPLATE: "{text} ({current}/{total})",
-    INPUT_STATS_EMPTY: "Characters: 0 | Words: 0 | Sentences: 0",
+    INPUT_STATS_EMPTY: "Characters: 0 | Words: 0 | Sentences: 0 | Paragraphs: 0",
     FEEDBACK_TITLE: "Feedback",
     FEEDBACK_EMAIL_LABEL: "Email:",
     FEEDBACK_EMAIL_PLACEHOLDER: "you@example.com",
@@ -49,6 +50,14 @@ export const TOGGLE_LABELS = Object.freeze({
     [TOGGLE_IDENTIFIERS.PARAGRAPH]: "Paragraphs",
     [TOGGLE_IDENTIFIERS.SENTENCE]: "Sentences",
     [TOGGLE_IDENTIFIERS.ENUMERATION]: "Enumerate"
+});
+
+export const ATTRIBUTE_NAMES = Object.freeze({
+    ARIA_DISABLED: "aria-disabled"
+});
+
+export const CLASS_NAMES = Object.freeze({
+    DISABLED: "disabled"
 });
 
 /** @type {Readonly<Record<string, number>>} */

--- a/js/core/chunking.js
+++ b/js/core/chunking.js
@@ -238,10 +238,16 @@ function buildBaseChunks(rawText, options) {
  * @returns {import("../types.d.js").ChunkStatistics} Derived statistics.
  */
 function calculateStatistics(chunkText) {
+    const paragraphMatches = chunkText
+        .split(PARAGRAPH_SPLITTER)
+        .map((paragraphText) => paragraphText.trim())
+        .filter((paragraphText) => paragraphText.length > 0);
+
     return {
         characters: chunkText.length,
         words: (chunkText.match(WORD_MATCHER) || []).length,
-        sentences: (chunkText.match(SENTENCE_MATCHER) || []).length
+        sentences: (chunkText.match(SENTENCE_MATCHER) || []).length,
+        paragraphs: paragraphMatches.length
     };
 }
 

--- a/js/types.d.js
+++ b/js/types.d.js
@@ -8,6 +8,7 @@
  * @property {number} characters Total number of characters contained in the chunk.
  * @property {number} words Total number of whitespace separated words contained in the chunk.
  * @property {number} sentences Total number of sentence-ending punctuation markers contained in the chunk.
+ * @property {number} paragraphs Total number of paragraphs contained in the chunk.
  */
 
 /**

--- a/js/ui/chunkListView.js
+++ b/js/ui/chunkListView.js
@@ -83,7 +83,7 @@ export class ChunkListView {
                     const statistics = this.chunkingService.calculateStatistics(statisticsSource);
                     const statsElement = document.createElement("div");
                     statsElement.className = "stats";
-                    statsElement.textContent = templateHelpers.interpolate(TEXT_CONTENT.STATS_TEMPLATE, {
+                    statsElement.textContent = templateHelpers.interpolate(TEXT_CONTENT.CHUNK_STATS_TEMPLATE, {
                         characters: statistics.characters,
                         words: statistics.words,
                         sentences: statistics.sentences

--- a/js/ui/controller.js
+++ b/js/ui/controller.js
@@ -91,6 +91,7 @@ export class ThreaderController {
         this.inputPanel.initializeCopy(titleElement, primaryDescriptionElement, secondaryDescriptionElement);
         footerElement.innerHTML = TEXT_CONTENT.FOOTER_HTML;
         this.formControls.initializeCopy();
+        this.formControls.setToggleAvailability(TOGGLE_IDENTIFIERS.PARAGRAPH, false);
         this.formControls.setActivePreset(null);
         this.attachEventListeners();
     }
@@ -158,6 +159,11 @@ export class ThreaderController {
             this.currentDocumentSnapshot = documentSnapshot;
             const statistics = this.chunkingService.calculateStatistics(documentSnapshot.plainText);
             this.inputPanel.updateStatistics(statistics);
+            const hasMultipleParagraphs = statistics.paragraphs > 1;
+            this.formControls.setToggleAvailability(TOGGLE_IDENTIFIERS.PARAGRAPH, hasMultipleParagraphs);
+            if (!hasMultipleParagraphs && this.state.breakOnParagraphs) {
+                this.state.breakOnParagraphs = false;
+            }
             if (this.rechunkTimeoutId !== null) {
                 window.clearTimeout(this.rechunkTimeoutId);
             }

--- a/js/ui/formControls.js
+++ b/js/ui/formControls.js
@@ -3,7 +3,15 @@
  * @fileoverview View model for preset buttons, custom input, and toggle controls.
  */
 
-import { TEXT_CONTENT, TOGGLE_LABELS, PRESET_IDENTIFIERS, PRESET_CONFIG, DEFAULT_LENGTHS } from "../constants.js";
+import {
+    TEXT_CONTENT,
+    TOGGLE_LABELS,
+    PRESET_IDENTIFIERS,
+    PRESET_CONFIG,
+    DEFAULT_LENGTHS,
+    ATTRIBUTE_NAMES,
+    CLASS_NAMES
+} from "../constants.js";
 
 /**
  * Handles form control interactions and exposes semantic events for the controller.
@@ -154,6 +162,35 @@ export class FormControls {
     setToggleState(identifier, checked) {
         if (this.toggleInputs[identifier]) {
             this.toggleInputs[identifier].checked = checked;
+        }
+    }
+
+    /**
+     * Enables or disables a toggle based on the current editor statistics.
+     * @param {string} identifier Toggle identifier to update.
+     * @param {boolean} isEnabled Whether the toggle should be interactive.
+     * @returns {void}
+     */
+    setToggleAvailability(identifier, isEnabled) {
+        const toggleElement = this.toggleInputs[identifier];
+        if (!toggleElement) {
+            return;
+        }
+
+        toggleElement.disabled = !isEnabled;
+        if (!isEnabled) {
+            toggleElement.checked = false;
+        }
+
+        const associatedLabel = this.toggleLabels[identifier];
+        if (associatedLabel) {
+            if (isEnabled) {
+                associatedLabel.removeAttribute(ATTRIBUTE_NAMES.ARIA_DISABLED);
+                associatedLabel.classList.remove(CLASS_NAMES.DISABLED);
+            } else {
+                associatedLabel.setAttribute(ATTRIBUTE_NAMES.ARIA_DISABLED, String(true));
+                associatedLabel.classList.add(CLASS_NAMES.DISABLED);
+            }
         }
     }
 

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -229,10 +229,11 @@ export class InputPanel {
      * @returns {void}
      */
     updateStatistics(statistics) {
-        this.statsElement.textContent = templateHelpers.interpolate(TEXT_CONTENT.STATS_TEMPLATE, {
+        this.statsElement.textContent = templateHelpers.interpolate(TEXT_CONTENT.INPUT_STATS_TEMPLATE, {
             characters: statistics.characters,
             words: statistics.words,
-            sentences: statistics.sentences
+            sentences: statistics.sentences,
+            paragraphs: statistics.paragraphs
         });
         this.adjustFontSize();
     }
@@ -287,8 +288,10 @@ export class InputPanel {
                 return;
             }
 
-            const htmlContent = clipboardData.getData("text/html");
-            const plainTextContent = clipboardData.getData("text/plain");
+            const clipboardGetData =
+                typeof clipboardData.getData === "function" ? clipboardData.getData.bind(clipboardData) : null;
+            const htmlContent = clipboardGetData ? clipboardGetData("text/html") : "";
+            const plainTextContent = clipboardGetData ? clipboardGetData("text/plain") : "";
             pasteEvent.preventDefault();
 
             /** @type {Array<() => Promise<void>>} */

--- a/tests/chunking.test.js
+++ b/tests/chunking.test.js
@@ -97,5 +97,6 @@ export async function runChunkingTests(runTest) {
         assertEqual(statistics.characters, 28, "character count should match");
         assertEqual(statistics.words, 6, "word count should match");
         assertEqual(statistics.sentences, 2, "sentence count should match");
+        assertEqual(statistics.paragraphs, 1, "paragraph count should match");
     });
 }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -239,6 +239,25 @@ export async function runIntegrationTests(runTest) {
             }
         },
         {
+            name: "paragraph toggle availability reflects paragraph count",
+            async execute() {
+                const { elements, cleanup } = setupControllerFixture();
+                try {
+                    elements.editorElement.textContent = "Single paragraph only.";
+                    elements.editorElement.dispatchEvent(new Event("input"));
+                    await waitForAnimationFrame();
+                    assertEqual(elements.paragraphToggle.disabled, true, "paragraph toggle should be disabled for single paragraph");
+
+                    elements.editorElement.textContent = "First paragraph.\n\nSecond paragraph.";
+                    elements.editorElement.dispatchEvent(new Event("input"));
+                    await waitForAnimationFrame();
+                    assertEqual(elements.paragraphToggle.disabled, false, "paragraph toggle should enable when multiple paragraphs exist");
+                } finally {
+                    cleanup();
+                }
+            }
+        },
+        {
             name: "enumeration toggle appends ordering metadata",
             async execute() {
                 const { elements, cleanup } = setupControllerFixture();


### PR DESCRIPTION
## Summary
- add paragraph counts to core statistics and UI state management
- disable the paragraph chunking toggle when only a single paragraph is present
- keep chunk statistics unchanged while extending tests for the new behavior

## Testing
- python -m http.server 8000 (manual server for browser tests)
- browser_container playwright script to run tests


------
https://chatgpt.com/codex/tasks/task_e_68d4fce6987083279217eb42519b13f1