### PR TITLE
Fix statistics for parenthetical sentences

### DIFF
--- a/tests/chunking.test.js
+++ b/tests/chunking.test.js
@@ -92,11 +92,33 @@ export async function runChunkingTests(runTest) {
         });
     }
 
-    await runTest("calculates statistics for provided text", () => {
-        const statistics = chunkingService.calculateStatistics("One two three. This is four?");
-        assertEqual(statistics.characters, 28, "character count should match");
-        assertEqual(statistics.words, 6, "word count should match");
-        assertEqual(statistics.sentences, 2, "sentence count should match");
-        assertEqual(statistics.paragraphs, 1, "paragraph count should match");
-    });
+    const statisticsCases = [
+        {
+            name: "calculates statistics for provided text",
+            input: "One two three. This is four?",
+            expected: {
+                characters: 28,
+                words: 6,
+                sentences: 2,
+                paragraphs: 1
+            }
+        },
+        {
+            name: "counts sentences and paragraphs when parentheses close text",
+            input: "First idea (alpha etc.)\rSecond idea (beta etc.)",
+            expected: {
+                characters: 47,
+                words: 8,
+                sentences: 2,
+                paragraphs: 2
+            }
+        }
+    ];
+
+    for (const statisticsCase of statisticsCases) {
+        await runTest(statisticsCase.name, () => {
+            const statistics = chunkingService.calculateStatistics(statisticsCase.input);
+            assertDeepEqual(statistics, statisticsCase.expected, "statistics should match expected values");
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- broaden paragraph splitting to recognize additional newline characters and reuse sentence-building logic for statistics
- ensure statistics reuse the chunking pipeline so sentences ending in parentheses are counted
- cover the regression scenario with table-driven tests for calculateStatistics

## Testing
- python -m http.server 8000 (manually exercised via Playwright to run tests/index.html)

------
https://chatgpt.com/codex/tasks/task_e_68d50b09a600832786c136e955fd7bfb