### PR TITLE
Toggle preset buttons to clear thread

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -57,7 +57,8 @@ export const ATTRIBUTE_NAMES = Object.freeze({
 });
 
 export const CLASS_NAMES = Object.freeze({
-    DISABLED: "disabled"
+    DISABLED: "disabled",
+    ACTIVE: "active"
 });
 
 /** @type {Readonly<Record<string, number>>} */

--- a/js/types.d.js
+++ b/js/types.d.js
@@ -27,7 +27,7 @@
 
 /**
  * @typedef {Object} ThreadingState
- * @property {number} activeLength Currently selected maximum chunk length.
+ * @property {number | null} activeLength Currently selected maximum chunk length when a preset or custom value is active.
  * @property {boolean} breakOnSentences Flag capturing the UI state for sentence preservation.
  * @property {boolean} enumerate Flag capturing the UI state for enumerating chunks.
  * @property {boolean} breakOnParagraphs Flag capturing the UI state for paragraph preservation.

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -14,7 +14,8 @@ import {
     PRESET_IDENTIFIERS,
     TOGGLE_IDENTIFIERS,
     DEFAULT_LENGTHS,
-    TEXT_CONTENT
+    TEXT_CONTENT,
+    CLASS_NAMES
 } from "../js/constants.js";
 import { assertEqual } from "./assert.js";
 
@@ -201,13 +202,13 @@ export async function runIntegrationTests(runTest) {
                     ];
                     for (const buttonElement of presetButtons) {
                         assertEqual(
-                            buttonElement.classList.contains("active"),
+                            buttonElement.classList.contains(CLASS_NAMES.ACTIVE),
                             false,
                             "preset buttons should start inactive"
                         );
                     }
                     assertEqual(
-                        elements.customButton.classList.contains("active"),
+                        elements.customButton.classList.contains(CLASS_NAMES.ACTIVE),
                         false,
                         "custom button should start inactive"
                     );
@@ -234,6 +235,50 @@ export async function runIntegrationTests(runTest) {
                     });
                     const renderedChunks = elements.resultsElement.querySelectorAll(".chunkContainer");
                     assertEqual(renderedChunks.length, expectedChunks.length, "rendered chunk count should match service output");
+                } finally {
+                    cleanup();
+                }
+            }
+        },
+        {
+            name: "preset button toggles off to clear the thread",
+            async execute() {
+                const { elements, cleanup } = setupControllerFixture();
+                try {
+                    const sampleText = Array.from({ length: 8 }, () => "Toggle behavior sample sentence.").join(" ");
+                    elements.editorElement.textContent = sampleText;
+                    elements.editorElement.dispatchEvent(new Event("input"));
+                    elements.presetTwitter.click();
+                    await waitForAnimationFrame();
+
+                    let renderedChunks = elements.resultsElement.querySelectorAll(".chunkContainer");
+                    assertEqual(renderedChunks.length > 0, true, "chunks should render when preset activates");
+                    assertEqual(
+                        elements.presetTwitter.classList.contains(CLASS_NAMES.ACTIVE),
+                        true,
+                        "preset button should be marked active after selection"
+                    );
+
+                    elements.presetTwitter.click();
+                    await waitForAnimationFrame();
+                    renderedChunks = elements.resultsElement.querySelectorAll(".chunkContainer");
+                    assertEqual(renderedChunks.length, 0, "chunks should clear when preset is toggled off");
+                    assertEqual(
+                        elements.presetTwitter.classList.contains(CLASS_NAMES.ACTIVE),
+                        false,
+                        "preset button should not remain active after toggling off"
+                    );
+
+                    elements.editorElement.textContent = `${sampleText} Additional content after toggle.`;
+                    elements.editorElement.dispatchEvent(new Event("input"));
+                    await new Promise((resolve) => setTimeout(resolve, 150));
+                    await waitForAnimationFrame();
+                    renderedChunks = elements.resultsElement.querySelectorAll(".chunkContainer");
+                    assertEqual(
+                        renderedChunks.length,
+                        0,
+                        "chunks should remain cleared until a preset is reselected"
+                    );
                 } finally {
                     cleanup();
                 }


### PR DESCRIPTION
## Summary
- add an ACTIVE class constant so preset buttons can share consistent styling state
- update the form controls and controller to treat preset buttons as toggles that clear the thread when deselected
- extend the integration suite with coverage for the new toggle-off behaviour and reuse the ACTIVE class constant in assertions

## Testing
- browser_container.run_playwright_script (loads tests/index.html)


------
https://chatgpt.com/codex/tasks/task_e_68d57ec268248327a15e68be2551275f