### PR TITLE
Add Playwright harness for browser tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -22,32 +22,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install Playwright browsers
-        run: npx --yes playwright@1.45.3 install --with-deps chromium
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Install Playwright test runner
-        run: npm install --no-save @playwright/test@1.45.3
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: Execute browser tests
-        run: |
-          cat <<'TEST' > ci.spec.js
-          const { test, expect } = require('@playwright/test');
-          const path = require('path');
-          const { pathToFileURL } = require('url');
-
-          const testPageUrl = pathToFileURL(path.resolve('tests/index.html')).toString();
-
-          test('browser suite passes', async ({ page }) => {
-            await page.goto(testPageUrl);
-            await page.waitForSelector('text=Passed:');
-
-            const summaryLocator = page.locator('#test-output p').last();
-            await expect(summaryLocator).toContainText('Failed: 0');
-
-            const failureCount = await page.locator('li', { hasText: '❌' }).count();
-            expect(failureCount).toBe(0);
-          });
-          TEST
-
-          npx --yes playwright@1.45.3 test ci.spec.js
-          rm ci.spec.js
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /shelf/
 /.idea/
 *.iml
+node_modules/
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "social-threader",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "social-threader",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.45.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
+      "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.45.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
+      "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.45.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
+      "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "social-threader",
+  "version": "1.0.0",
+  "description": "Browser test harness and Playwright runner for Social Threader",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.45.3"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,11 @@
+const { defineConfig } = require("@playwright/test");
+
+const PLAYWRIGHT_TEST_DIRECTORY = "playwright";
+
+module.exports = defineConfig({
+    testDir: PLAYWRIGHT_TEST_DIRECTORY,
+    retries: process.env.CI ? 2 : 0,
+    use: {
+        headless: true
+    }
+});

--- a/playwright/ci.spec.js
+++ b/playwright/ci.spec.js
@@ -1,0 +1,26 @@
+const { test, expect } = require("@playwright/test");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const TEST_HARNESS_DIRECTORY_NAME = "tests";
+const TEST_HARNESS_FILE_NAME = "index.html";
+const FAILURE_ICON = "❌";
+const SUMMARY_SELECTOR = "#test-output p:last-of-type";
+const SUMMARY_EXPECTATION_PATTERN = /Passed: \d+, Failed: 0/;
+const TEST_SUITE_DESCRIPTION = "browser test harness";
+const CLEAN_SUMMARY_TEST_DESCRIPTION = "reports a clean test summary";
+
+const testHarnessFilePath = path.join(__dirname, "..", TEST_HARNESS_DIRECTORY_NAME, TEST_HARNESS_FILE_NAME);
+const testHarnessUrl = pathToFileURL(testHarnessFilePath).href;
+
+test.describe(TEST_SUITE_DESCRIPTION, () => {
+    test(CLEAN_SUMMARY_TEST_DESCRIPTION, async ({ page }) => {
+        await page.goto(testHarnessUrl);
+
+        const summaryLocator = page.locator(SUMMARY_SELECTOR);
+        await expect(summaryLocator).toHaveText(SUMMARY_EXPECTATION_PATTERN);
+
+        const failingTestLocator = page.locator(`#test-output li:has-text("${FAILURE_ICON}")`);
+        await expect(failingTestLocator).toHaveCount(0);
+    });
+});


### PR DESCRIPTION
## Plan
- Add committed Playwright spec that loads the browser-based test runner
- Provide npm metadata so CI can install Playwright and invoke the suite
- Ignore runtime Playwright artifacts in git
- Update the CI workflow to execute the committed spec directly instead of generating it on the fly

## Summary
- add package.json and lockfile to install @playwright/test with an npm test script
- configure Playwright to look for specs in a dedicated playwright/ directory
- commit a ci.spec.js that opens tests/index.html and asserts that the browser runner reports no failures
- expand .gitignore to cover node_modules and Playwright output folders
- update the GitHub Actions workflow to install dependencies and run npm test against the committed Playwright spec

## Testing
- npm test *(fails: Playwright Chromium download blocked by proxy)*
- npx playwright install --with-deps chromium *(fails: Playwright Chromium download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d589c4078c8327888fb411d31c873c