### PR TITLE
Guard ClipboardItem stub

### DIFF
--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -71,11 +71,13 @@ class ClipboardItemStub {
     }
 }
 
-Object.defineProperty(window, "ClipboardItem", {
-    value: ClipboardItemStub,
-    configurable: true,
-    writable: true
-});
+if (typeof window.ClipboardItem !== "function") {
+    Object.defineProperty(window, "ClipboardItem", {
+        value: ClipboardItemStub,
+        configurable: true,
+        writable: true
+    });
+}
 
 /**
  * @returns {Promise<void>}


### PR DESCRIPTION
## Summary
- add a safeguard around the ClipboardItem stub so the shim only applies when the runtime lacks a native implementation

## Testing
- npm test *(fails: Playwright browser download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bd51015083278c0657950efbba17