### PR TITLE
Prevent double bootstrap and init on parsed DOM

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -71,11 +71,18 @@ function initializeFeedbackWidget() {
     });
 }
 
+/** @type {boolean} */
+let bootstrapHasInitialized = false;
+
 /**
  * Bootstraps the UI after DOM content is ready.
  * @returns {void}
  */
 function bootstrap() {
+    if (bootstrapHasInitialized) {
+        return;
+    }
+    bootstrapHasInitialized = true;
     const titleElement = assertElement(document.getElementById("appTitle"), "appTitle");
     const primaryDescriptionElement = assertElement(document.getElementById("primaryDescription"), "primaryDescription");
     const secondaryDescriptionElement = assertElement(document.getElementById("secondaryDescription"), "secondaryDescription");
@@ -125,3 +132,7 @@ function bootstrap() {
 }
 
 document.addEventListener("DOMContentLoaded", bootstrap);
+
+if (document.readyState !== "loading") {
+    bootstrap();
+}


### PR DESCRIPTION
## Summary
- track whether bootstrap has already run before wiring DOM dependencies
- invoke bootstrap immediately when the document is already parsed to cover pre-loaded scenarios

## Testing
- npm test *(fails: playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d3703dec8327b58f95a8e478565d