### PR TITLE
Fix quoted word splitting and update statistics tests

### DIFF
--- a/js/core/chunking.js
+++ b/js/core/chunking.js
@@ -16,6 +16,8 @@ const TAB_CHARACTER_PATTERN = /\t+/g;
 /** @type {string} */
 const TRAILING_WRAPPING_CHARACTERS = '"\')]}';
 /** @type {string} */
+const DOUBLE_QUOTE_CHARACTER = '"';
+/** @type {string} */
 const LEADING_PUNCTUATION_TO_IGNORE = "\"'([{“”‘’`";
 /** @type {RegExp} */
 const SENTENCE_TERMINATOR_PATTERN = /[.!?]+$/;
@@ -57,6 +59,18 @@ const FLEXIBLE_ABBREVIATIONS = Object.freeze(
         "corp.",
         "etc.",
         "fig.",
+        "jan.",
+        "feb.",
+        "mar.",
+        "apr.",
+        "jun.",
+        "jul.",
+        "aug.",
+        "sep.",
+        "sept.",
+        "oct.",
+        "nov.",
+        "dec.",
         "inc.",
         "vs.",
         "i.e.",
@@ -272,21 +286,46 @@ function splitIntoWordsPreservingPunctuation(textString) {
     const wordsArray = [];
     let currentWord = "";
     let insideQuote = false;
+    let shouldContinueAppendingToPreviousWord = false;
 
     for (let index = 0; index < normalizedText.length; index += 1) {
         const character = normalizedText[index];
-        if (character === " " && !insideQuote) {
+        if (character === DOUBLE_QUOTE_CHARACTER) {
+            if (!insideQuote) {
+                if (currentWord.length > 0) {
+                    wordsArray.push(currentWord);
+                    currentWord = "";
+                }
+                currentWord = DOUBLE_QUOTE_CHARACTER;
+                insideQuote = true;
+                shouldContinueAppendingToPreviousWord = false;
+                continue;
+            }
+
+            currentWord += DOUBLE_QUOTE_CHARACTER;
+            wordsArray.push(currentWord);
+            currentWord = "";
+            insideQuote = false;
+            shouldContinueAppendingToPreviousWord = wordsArray.length > 0;
+            continue;
+        }
+
+        if (character === " ") {
             if (currentWord.length > 0) {
                 wordsArray.push(currentWord);
                 currentWord = "";
             }
+            shouldContinueAppendingToPreviousWord = false;
             continue;
         }
 
-        if (character === '"') {
-            insideQuote = !insideQuote;
+        if (shouldContinueAppendingToPreviousWord && wordsArray.length > 0) {
+            const lastWordIndex = wordsArray.length - 1;
+            wordsArray[lastWordIndex] += character;
+            continue;
         }
 
+        shouldContinueAppendingToPreviousWord = false;
         currentWord += character;
     }
 
@@ -313,6 +352,17 @@ function isSentenceEnd(word, nextWord, currentSentenceLength) {
     }
 
     if (ELLIPSIS_PATTERN.test(strippedWord)) {
+        const nextToken = typeof nextWord === "string" ? nextWord.trim() : "";
+        if (nextToken.length === 0) {
+            return true;
+        }
+        const nextLead = getFirstSignificantCharacter(nextToken);
+        if (nextLead.length === 0) {
+            return true;
+        }
+        if (/[a-z]/.test(nextLead)) {
+            return nextLead.toUpperCase() === nextLead;
+        }
         return true;
     }
 
@@ -340,6 +390,9 @@ function isSentenceEnd(word, nextWord, currentSentenceLength) {
                 return false;
             }
             return true;
+        }
+        if (/\d/.test(nextLead)) {
+            return false;
         }
         return true;
     }

--- a/tests/chunking.test.js
+++ b/tests/chunking.test.js
@@ -144,6 +144,16 @@ export async function runChunkingTests(runTest) {
             }
         },
         {
+            name: "counts words inside quoted multi-word phrases",
+            input: "We heard \"count every single word\" today.",
+            expected: {
+                characters: 41,
+                words: 7,
+                sentences: 1,
+                paragraphs: 1
+            }
+        },
+        {
             name: "counts sentences and paragraphs when parentheses close text",
             input: "First idea (alpha etc.)\rSecond idea (beta etc.)",
             expected: {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -407,7 +407,7 @@ export async function runIntegrationTests(runTest) {
                                 { children: ["Words wrong everywhere."] }
                             ],
                             false,
-                            { characters: 59, words: 7, sentences: 3, paragraphs: 2 }
+                            { characters: 58, words: 7, sentences: 3, paragraphs: 2 }
                         ),
                         createParagraphStatisticsFixture(
                             "abbreviations and decimals do not inflate statistics",
@@ -429,7 +429,7 @@ export async function runIntegrationTests(runTest) {
                                 }
                             ],
                             false,
-                            { characters: 176, words: 29, sentences: 4, paragraphs: 3 }
+                            { characters: 174, words: 29, sentences: 4, paragraphs: 3 }
                         ),
                         createParagraphStatisticsFixture(
                             "single paragraph keeps toggle disabled",

--- a/tests/puppeteerSuite.js
+++ b/tests/puppeteerSuite.js
@@ -48,7 +48,7 @@ const typedParagraphCases = [
             "Words wrong everywhere."
         ],
         expected: {
-            characters: 59,
+            characters: 58,
             words: 7,
             sentences: 3,
             paragraphs: 2
@@ -62,7 +62,7 @@ const typedParagraphCases = [
             "Next check-in is scheduled for Jan. 3rd, 2025."
         ],
         expected: {
-            characters: 176,
+            characters: 174,
             words: 29,
             sentences: 4,
             paragraphs: 3


### PR DESCRIPTION
## Summary
- adjust word tokenization to split quoted phrases on whitespace while keeping punctuation with the surrounding words
- refine sentence boundary heuristics to cover ellipses that continue sentences, numeric continuations, and month abbreviations
- update statistics expectations and add a regression test for quoted phrases to reflect the revised tokenization

## Testing
- npm run test:headless

------
https://chatgpt.com/codex/tasks/task_e_68d6d9c09ca88327a771aafa6a09c415