### PR TITLE
Handle month abbreviations with ordinals

### DIFF
--- a/js/core/chunking.js
+++ b/js/core/chunking.js
@@ -63,6 +63,7 @@ const FLEXIBLE_ABBREVIATIONS = Object.freeze(
         "feb.",
         "mar.",
         "apr.",
+        "may.",
         "jun.",
         "jul.",
         "aug.",

--- a/tests/chunking.test.js
+++ b/tests/chunking.test.js
@@ -226,6 +226,16 @@ export async function runChunkingTests(runTest) {
             }
         },
         {
+            name: "treats month abbreviations followed by ordinals as a single sentence",
+            input: "The festival begins on May. 5th at noon. Please arrive early.",
+            expected: {
+                characters: 61,
+                words: 11,
+                sentences: 2,
+                paragraphs: 1
+            }
+        },
+        {
             name: "ignores abbreviations while counting sentences",
             input: "Please schedule a visit with Dr. Smith tomorrow. Bring completed forms.",
             expected: {


### PR DESCRIPTION
## Summary
- add the missing month abbreviation to the flexible abbreviation set so all standard months are covered
- extend the chunking statistics tests with a case that exercises a month abbreviation followed by an ordinal

## Testing
- npm run test:headless

------
https://chatgpt.com/codex/tasks/task_e_68d6e27d30ac8327b32ddf140958d0fd