### PR TITLE
Improve statistics heuristics for paragraphs and abbreviations

### DIFF
--- a/js/core/chunking.js
+++ b/js/core/chunking.js
@@ -118,12 +118,25 @@ function stripTrailingWrappingCharacters(token) {
 }
 
 /**
+ * Strips leading wrapping characters such as quotes or parentheses.
+ * @param {string} token Word token to sanitize.
+ * @returns {string} Token without leading wrapping characters.
+ */
+function stripLeadingWrappingCharacters(token) {
+    let sanitizedToken = token;
+    while (sanitizedToken.length > 0 && LEADING_PUNCTUATION_TO_IGNORE.includes(sanitizedToken.charAt(0))) {
+        sanitizedToken = sanitizedToken.slice(1);
+    }
+    return sanitizedToken;
+}
+
+/**
  * Determines the classification of an abbreviation if applicable.
  * @param {string} token Candidate token potentially representing an abbreviation.
  * @returns {"strict" | "flexible" | null} Classification result or null when not an abbreviation.
  */
 function classifyAbbreviation(token) {
-    const normalizedToken = stripTrailingWrappingCharacters(token).toLowerCase();
+    const normalizedToken = stripTrailingWrappingCharacters(stripLeadingWrappingCharacters(token)).toLowerCase();
     if (normalizedToken.length === 0) {
         return null;
     }
@@ -153,7 +166,7 @@ function classifyAbbreviation(token) {
  * @returns {boolean} True when the token is decimal-like and should not end a sentence.
  */
 function isDecimalNotation(token) {
-    const normalizedToken = stripTrailingWrappingCharacters(token).toLowerCase();
+    const normalizedToken = stripTrailingWrappingCharacters(stripLeadingWrappingCharacters(token)).toLowerCase();
     return DECIMAL_LIKE_PATTERN.test(normalizedToken);
 }
 

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -264,10 +264,24 @@ export class InputPanel {
         const inertEditor = /** @type {HTMLDivElement} */ (inertDocument.importNode(clonedEditor, true));
         inertDocument.body.appendChild(inertEditor);
 
+        const inertChildNodes = Array.from(inertEditor.childNodes);
+        const sampleNodeForNodeType = inertChildNodes[0] ?? inertEditor;
+        const windowNodeConstructor = typeof window === "undefined" ? undefined : window.Node;
+        const nodeConstructor =
+            sampleNodeForNodeType.ownerDocument?.defaultView?.Node ?? windowNodeConstructor;
+        const resolvedTextNodeType =
+            typeof nodeConstructor === "undefined" || nodeConstructor === null
+                ? 3
+                : nodeConstructor.TEXT_NODE;
+        const resolvedElementNodeType =
+            typeof nodeConstructor === "undefined" || nodeConstructor === null
+                ? 1
+                : nodeConstructor.ELEMENT_NODE;
+
         /** @type {(string | symbol)[]} */
         const placeholderSegments = [];
-        inertEditor.childNodes.forEach((childNode) => {
-            if (childNode.nodeType === Node.TEXT_NODE) {
+        inertChildNodes.forEach((childNode) => {
+            if (childNode.nodeType === resolvedTextNodeType) {
                 const textContent = childNode.textContent || "";
                 const normalizedText = normalizeEditorText(textContent).replace(
                     TRAILING_NEWLINE_PATTERN,
@@ -280,7 +294,7 @@ export class InputPanel {
                 return;
             }
 
-            if (childNode.nodeType === Node.ELEMENT_NODE) {
+            if (childNode.nodeType === resolvedElementNodeType) {
                 const element = /** @type {HTMLElement} */ (childNode);
                 const normalizedInnerText = serializeElementTextWithSoftBreaks(element);
                 const trimmedInnerText = normalizedInnerText.replace(

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -306,11 +306,8 @@ export class InputPanel {
 
             const segmentText = /** @type {string} */ (segment);
             if (hasWrittenText) {
-                if (pendingSeparatorCount === 0) {
-                    normalizedPlaceholderText += SINGLE_NEWLINE;
-                } else {
-                    normalizedPlaceholderText += DOUBLE_NEWLINE.repeat(pendingSeparatorCount);
-                }
+                const separatorCount = Math.max(1, pendingSeparatorCount);
+                normalizedPlaceholderText += DOUBLE_NEWLINE.repeat(separatorCount);
             }
             normalizedPlaceholderText += segmentText;
             hasWrittenText = true;

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -267,7 +267,7 @@ export class InputPanel {
         /** @type {(string | symbol)[]} */
         const placeholderSegments = [];
         inertEditor.childNodes.forEach((childNode) => {
-            if (childNode instanceof window.Text) {
+            if (childNode.nodeType === Node.TEXT_NODE) {
                 const textContent = childNode.textContent || "";
                 const normalizedText = normalizeEditorText(textContent).replace(
                     TRAILING_NEWLINE_PATTERN,
@@ -280,8 +280,8 @@ export class InputPanel {
                 return;
             }
 
-            if (childNode instanceof HTMLElement) {
-                const element = childNode;
+            if (childNode.nodeType === Node.ELEMENT_NODE) {
+                const element = /** @type {HTMLElement} */ (childNode);
                 const normalizedInnerText = serializeElementTextWithSoftBreaks(element);
                 const trimmedInnerText = normalizedInnerText.replace(
                     TRAILING_NEWLINE_PATTERN,

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -265,18 +265,23 @@ export class InputPanel {
         inertDocument.body.appendChild(inertEditor);
 
         const inertChildNodes = Array.from(inertEditor.childNodes);
-        const sampleNodeForNodeType = inertChildNodes[0] ?? inertEditor;
-        const windowNodeConstructor = typeof window === "undefined" ? undefined : window.Node;
-        const nodeConstructor =
-            sampleNodeForNodeType.ownerDocument?.defaultView?.Node ?? windowNodeConstructor;
-        const resolvedTextNodeType =
-            typeof nodeConstructor === "undefined" || nodeConstructor === null
-                ? 3
-                : nodeConstructor.TEXT_NODE;
-        const resolvedElementNodeType =
-            typeof nodeConstructor === "undefined" || nodeConstructor === null
-                ? 1
-                : nodeConstructor.ELEMENT_NODE;
+        const fallbackNodeConstructor = typeof window === "undefined" ? undefined : window.Node;
+        /** @type {{ text: number; element: number } | null} */
+        let resolvedNodeTypeValues = null;
+        inertChildNodes.some((childNode) => {
+            const nodeConstructor =
+                childNode.ownerDocument?.defaultView?.Node ?? fallbackNodeConstructor;
+            if (typeof nodeConstructor === "undefined" || nodeConstructor === null) {
+                return false;
+            }
+            resolvedNodeTypeValues = {
+                text: nodeConstructor.TEXT_NODE,
+                element: nodeConstructor.ELEMENT_NODE
+            };
+            return true;
+        });
+        const resolvedTextNodeType = resolvedNodeTypeValues?.text ?? 3;
+        const resolvedElementNodeType = resolvedNodeTypeValues?.element ?? 1;
 
         /** @type {(string | symbol)[]} */
         const placeholderSegments = [];

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -306,7 +306,11 @@ export class InputPanel {
 
             const segmentText = /** @type {string} */ (segment);
             if (hasWrittenText) {
-                normalizedPlaceholderText += DOUBLE_NEWLINE;
+                if (pendingSeparatorCount === 0) {
+                    normalizedPlaceholderText += SINGLE_NEWLINE;
+                } else {
+                    normalizedPlaceholderText += DOUBLE_NEWLINE.repeat(pendingSeparatorCount);
+                }
             }
             normalizedPlaceholderText += segmentText;
             hasWrittenText = true;

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -30,6 +30,21 @@ function normalizeEditorText(text) {
 }
 
 /**
+ * Serializes an element's text content, converting soft breaks to newline characters.
+ * @param {HTMLElement} element Element whose textual content should be extracted.
+ * @returns {string} Text content with `<br>` tags replaced by newline characters.
+ */
+function serializeElementTextWithSoftBreaks(element) {
+    const inertDocument = document.implementation.createHTMLDocument("element-text-serialization");
+    const clonedElement = /** @type {HTMLElement} */ (inertDocument.importNode(element, true));
+    clonedElement.querySelectorAll("br").forEach((lineBreakElement) => {
+        lineBreakElement.replaceWith(inertDocument.createTextNode(SINGLE_NEWLINE));
+    });
+    const serializedTextContent = clonedElement.textContent || "";
+    return normalizeEditorText(serializedTextContent);
+}
+
+/**
  * Determines whether text is empty or contains only newline characters once normalized.
  * @param {string} normalizedText Text that has already passed through normalizeEditorText.
  * @returns {boolean} True when the text contains no visible characters.
@@ -267,7 +282,7 @@ export class InputPanel {
 
             if (childNode instanceof HTMLElement) {
                 const element = childNode;
-                const normalizedInnerText = normalizeEditorText(element.innerText);
+                const normalizedInnerText = serializeElementTextWithSoftBreaks(element);
                 const trimmedInnerText = normalizedInnerText.replace(
                     TRAILING_NEWLINE_PATTERN,
                     ""
@@ -291,13 +306,7 @@ export class InputPanel {
 
             const segmentText = /** @type {string} */ (segment);
             if (hasWrittenText) {
-                if (pendingSeparatorCount === 0) {
-                    normalizedPlaceholderText += DOUBLE_NEWLINE;
-                } else if (pendingSeparatorCount === 1) {
-                    normalizedPlaceholderText += SINGLE_NEWLINE;
-                } else {
-                    normalizedPlaceholderText += DOUBLE_NEWLINE;
-                }
+                normalizedPlaceholderText += DOUBLE_NEWLINE;
             }
             normalizedPlaceholderText += segmentText;
             hasWrittenText = true;

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -18,6 +18,7 @@ const SINGLE_NEWLINE = "\n";
 /** @type {string} */
 const DOUBLE_NEWLINE = "\n\n";
 const PLACEHOLDER_SEPARATOR_FLAG = Symbol("placeholderSeparatorFlag");
+const TRAILING_NEWLINE_PATTERN = /\n+$/u;
 
 /**
  * Normalizes editor text content by replacing non-breaking spaces and Windows newlines.
@@ -253,7 +254,10 @@ export class InputPanel {
         inertEditor.childNodes.forEach((childNode) => {
             if (childNode instanceof window.Text) {
                 const textContent = childNode.textContent || "";
-                const normalizedText = normalizeEditorText(textContent);
+                const normalizedText = normalizeEditorText(textContent).replace(
+                    TRAILING_NEWLINE_PATTERN,
+                    ""
+                );
                 if (normalizedText.trim().length === 0) {
                     return;
                 }
@@ -264,11 +268,15 @@ export class InputPanel {
             if (childNode instanceof HTMLElement) {
                 const element = childNode;
                 const normalizedInnerText = normalizeEditorText(element.innerText);
-                if (isEmptyOrNewlineOnly(normalizedInnerText)) {
+                const trimmedInnerText = normalizedInnerText.replace(
+                    TRAILING_NEWLINE_PATTERN,
+                    ""
+                );
+                if (isEmptyOrNewlineOnly(trimmedInnerText)) {
                     placeholderSegments.push(PLACEHOLDER_SEPARATOR_FLAG);
                     return;
                 }
-                placeholderSegments.push(normalizedInnerText);
+                placeholderSegments.push(trimmedInnerText);
             }
         });
 

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -13,7 +13,8 @@ const SNAPSHOT_ASSERTION_MESSAGES = Object.freeze({
     plainTextMismatch: "Snapshot plain text should match expected newline separated paragraphs",
     serializedLengthMismatch: "Serialized placeholder text should match the expected character length",
     plainTextLengthMismatch: "Snapshot plain text should match the expected character length",
-    statisticsTextMismatch: "Statistics summary should match expected template output when Node constructor is removed"
+    statisticsTextMismatch:
+        "Statistics summary should match expected template output when globalThis.Node constructor is removed"
 });
 
 const PARAGRAPH_TEXT_CONTENT = Object.freeze({
@@ -260,7 +261,7 @@ const DOCUMENT_CASES = [
         ]
     },
     {
-        name: "captures text and statistics when Node constructor is removed",
+        name: "captures text and statistics when globalThis.Node constructor is removed",
         expectedText: EXPECTED_SNAPSHOT_TEXT.sequentialParagraphs,
         builderSteps: SEQUENTIAL_PARAGRAPH_BUILDER_STEPS,
         prepareEnvironment: () => {

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -24,10 +24,16 @@ const PARAGRAPH_TEXT_CONTENT = Object.freeze({
     inlineLinkTrailingText: " enriched paragraph content."
 });
 
+const SOFT_BREAK_TEXT_CONTENT = Object.freeze({
+    firstLine: "Soft line breaks remain within paragraphs.",
+    secondLine: "Soft line breaks should not create new paragraphs."
+});
+
 const EXPECTED_SNAPSHOT_TEXT = Object.freeze({
     sequentialParagraphs: "Paragraph #1.\n\nParagraph #2.\n\nParagraph #3.",
     inlineEmphasis: "Intro with emphasis highlighted conclusion.",
-    mixedInlineElements: "Leading strong text and trailing content.\n\nLink enriched paragraph content."
+    mixedInlineElements: "Leading strong text and trailing content.\n\nLink enriched paragraph content.",
+    softLineBreakParagraph: `${SOFT_BREAK_TEXT_CONTENT.firstLine}\n${SOFT_BREAK_TEXT_CONTENT.secondLine}`
 });
 
 const INLINE_ELEMENT_TEXT = Object.freeze({
@@ -43,7 +49,7 @@ const INLINE_ELEMENT_URLS = Object.freeze({
 const EDITOR_SEPARATOR_REGRESSION_TEXT = Object.freeze({
     firstParagraph: "Puppeteer ensures reliable browser coverage.",
     secondParagraph: "Browser automation validates paragraph counts.",
-    expectedLength: 91
+    expectedLength: 92
 });
 
 /**
@@ -131,8 +137,8 @@ const DOCUMENT_CASES = [
         ]
     },
     {
-        name: "treats spacer divs as single newline separators",
-        expectedText: `${EDITOR_SEPARATOR_REGRESSION_TEXT.firstParagraph}\n${EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph}`,
+        name: "expands spacer divs to paragraph separators",
+        expectedText: `${EDITOR_SEPARATOR_REGRESSION_TEXT.firstParagraph}\n\n${EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph}`,
         expectedLength: EDITOR_SEPARATOR_REGRESSION_TEXT.expectedLength,
         builderSteps: [
             /**
@@ -150,6 +156,23 @@ const DOCUMENT_CASES = [
             (targetEditorElement) => {
                 appendParagraphWithChildren(targetEditorElement, [
                     document.createTextNode(EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph)
+                ]);
+            },
+            appendEmptyParagraph
+        ]
+    },
+    {
+        name: "preserves soft line breaks within paragraph boundaries",
+        expectedText: EXPECTED_SNAPSHOT_TEXT.softLineBreakParagraph,
+        builderSteps: [
+            /**
+             * @param {HTMLDivElement} targetEditorElement
+             */
+            (targetEditorElement) => {
+                appendParagraphWithChildren(targetEditorElement, [
+                    document.createTextNode(SOFT_BREAK_TEXT_CONTENT.firstLine),
+                    document.createElement("br"),
+                    document.createTextNode(SOFT_BREAK_TEXT_CONTENT.secondLine)
                 ]);
             },
             appendEmptyParagraph

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -33,13 +33,6 @@ const SOFT_BREAK_TEXT_CONTENT = Object.freeze({
     secondLine: "Soft line breaks should not create new paragraphs."
 });
 
-const EXPECTED_SNAPSHOT_TEXT = Object.freeze({
-    sequentialParagraphs: "Paragraph #1.\n\nParagraph #2.\n\nParagraph #3.",
-    inlineEmphasis: "Intro with emphasis highlighted conclusion.",
-    mixedInlineElements: "Leading strong text and trailing content.\n\nLink enriched paragraph content.",
-    softLineBreakParagraph: `${SOFT_BREAK_TEXT_CONTENT.firstLine}\n${SOFT_BREAK_TEXT_CONTENT.secondLine}`
-});
-
 const NODE_REMOVAL_EXPECTED_STATISTICS = Object.freeze({
     characters: 43,
     words: 6,
@@ -68,6 +61,14 @@ const EDITOR_SEPARATOR_REGRESSION_TEXT = Object.freeze({
     firstParagraph: "Puppeteer ensures reliable browser coverage.",
     secondParagraph: "Browser automation validates paragraph counts.",
     expectedLength: 92
+});
+
+const EXPECTED_SNAPSHOT_TEXT = Object.freeze({
+    sequentialParagraphs: "Paragraph #1.\n\nParagraph #2.\n\nParagraph #3.",
+    inlineEmphasis: "Intro with emphasis highlighted conclusion.",
+    mixedInlineElements: "Leading strong text and trailing content.\n\nLink enriched paragraph content.",
+    softLineBreakParagraph: `${SOFT_BREAK_TEXT_CONTENT.firstLine}\n${SOFT_BREAK_TEXT_CONTENT.secondLine}`,
+    doubleSpacerParagraphs: `${EDITOR_SEPARATOR_REGRESSION_TEXT.firstParagraph}\n\n\n\n${EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph}`
 });
 
 /**
@@ -132,6 +133,28 @@ const SEQUENTIAL_PARAGRAPH_BUILDER_STEPS = Object.freeze([
     (targetEditorElement) => {
         appendParagraphWithChildren(targetEditorElement, [
             document.createTextNode(PARAGRAPH_TEXT_CONTENT.thirdParagraph)
+        ]);
+    },
+    appendEmptyParagraph
+]);
+
+const DOUBLE_SPACER_PARAGRAPH_BUILDER_STEPS = Object.freeze([
+    /**
+     * @param {HTMLDivElement} targetEditorElement
+     */
+    (targetEditorElement) => {
+        appendParagraphWithChildren(targetEditorElement, [
+            document.createTextNode(EDITOR_SEPARATOR_REGRESSION_TEXT.firstParagraph)
+        ]);
+    },
+    appendEmptyParagraph,
+    appendEmptyParagraph,
+    /**
+     * @param {HTMLDivElement} targetEditorElement
+     */
+    (targetEditorElement) => {
+        appendParagraphWithChildren(targetEditorElement, [
+            document.createTextNode(EDITOR_SEPARATOR_REGRESSION_TEXT.secondParagraph)
         ]);
     },
     appendEmptyParagraph
@@ -281,6 +304,12 @@ const NODE_CONSTRUCTOR_REGRESSION_CASES = Object.freeze([
         expectedPlainText: EXPECTED_SNAPSHOT_TEXT.sequentialParagraphs,
         expectedStatistics: NODE_REMOVAL_EXPECTED_STATISTICS,
         expectedStatisticsText: EXPECTED_STATISTICS_TEXT.nodeConstructorRemoved
+    },
+    {
+        name: "reconstructs paragraph separators with consecutive empty paragraphs when globalThis.Node constructor is removed",
+        builderSteps: DOUBLE_SPACER_PARAGRAPH_BUILDER_STEPS,
+        expectedPlaceholderText: EXPECTED_SNAPSHOT_TEXT.doubleSpacerParagraphs,
+        expectedPlainText: EXPECTED_SNAPSHOT_TEXT.doubleSpacerParagraphs
     }
 ]);
 

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -23,9 +23,9 @@ const PARAGRAPH_TEXT_CONTENT = Object.freeze({
 });
 
 const EXPECTED_SNAPSHOT_TEXT = Object.freeze({
-    sequentialParagraphs: "Paragraph #1.\nParagraph #2.\nParagraph #3.",
+    sequentialParagraphs: "Paragraph #1.\n\nParagraph #2.\n\nParagraph #3.",
     inlineEmphasis: "Intro with emphasis highlighted conclusion.",
-    mixedInlineElements: "Leading strong text and trailing content.\nLink enriched paragraph content."
+    mixedInlineElements: "Leading strong text and trailing content.\n\nLink enriched paragraph content."
 });
 
 const INLINE_ELEMENT_TEXT = Object.freeze({

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -9,7 +9,8 @@ import { assertEqual } from "./assert.js";
 const SNAPSHOT_ASSERTION_MESSAGES = Object.freeze({
     placeholderMismatch: "Snapshot placeholder text should match expected newline separated paragraphs",
     plainTextMismatch: "Snapshot plain text should match expected newline separated paragraphs",
-    serializedLengthMismatch: "Serialized text should match the expected character length"
+    serializedLengthMismatch: "Serialized placeholder text should match the expected character length",
+    plainTextLengthMismatch: "Snapshot plain text should match the expected character length"
 });
 
 const PARAGRAPH_TEXT_CONTENT = Object.freeze({
@@ -235,6 +236,11 @@ export async function runInputPanelTests(runTest) {
                         snapshot.placeholderText.length,
                         documentCase.expectedLength,
                         SNAPSHOT_ASSERTION_MESSAGES.serializedLengthMismatch
+                    );
+                    assertEqual(
+                        snapshot.plainText.length,
+                        documentCase.expectedLength,
+                        SNAPSHOT_ASSERTION_MESSAGES.plainTextLengthMismatch
                     );
                 }
             } finally {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -444,7 +444,7 @@ export async function runIntegrationTests(runTest) {
                                 { children: ["Second paragraph."] }
                             ],
                             false,
-                            { characters: 34, words: 4, sentences: 2, paragraphs: 2 }
+                            { characters: 35, words: 4, sentences: 2, paragraphs: 2 }
                         ),
                         createParagraphStatisticsFixture(
                             "inline formatting paragraphs preserve counts",
@@ -454,7 +454,7 @@ export async function runIntegrationTests(runTest) {
                                 { children: ["Paragraph ", { tagName: "strong", text: "#3" }, "."] }
                             ],
                             false,
-                            { characters: 41, words: 6, sentences: 3, paragraphs: 3 }
+                            { characters: 43, words: 6, sentences: 3, paragraphs: 3 }
                         ),
                         createParagraphStatisticsFixture(
                             "trailing blank paragraph is ignored",
@@ -465,7 +465,7 @@ export async function runIntegrationTests(runTest) {
                                 { isBlank: true }
                             ],
                             false,
-                            { characters: 41, words: 6, sentences: 3, paragraphs: 3 }
+                            { characters: 43, words: 6, sentences: 3, paragraphs: 3 }
                         )
                     ];
 

--- a/tests/puppeteerSuite.js
+++ b/tests/puppeteerSuite.js
@@ -35,7 +35,7 @@ const typedParagraphCases = [
             "Browser automation validates paragraph counts."
         ],
         expected: {
-            characters: 91,
+            characters: 92,
             words: 10,
             sentences: 2,
             paragraphs: 2


### PR DESCRIPTION
## Summary
- expand the flexible abbreviation set and refine sentence termination to handle ellipses and digit-followed abbreviations correctly
- rewrite the InputPanel snapshot builder so paragraph separation is preserved in placeholder and plain-text output
- align InputPanel and integration tests with the normalized paragraph serialization and updated character counts

## Testing
- `npm run test:headless`
- `npm run test:browser` *(fails: Puppeteer cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d653d761c883278e778159fdacabdf