### PR TITLE
Fix paragraph snapshot and improve statistics heuristics

### DIFF
--- a/js/core/chunking.js
+++ b/js/core/chunking.js
@@ -190,7 +190,14 @@ function shouldStartNewParagraph(previousLine, currentLine) {
         return false;
     }
 
-    return firstCharacter.toUpperCase() === firstCharacter;
+    if (firstCharacter.toUpperCase() === firstCharacter) {
+        return true;
+    }
+
+    // Contenteditable paragraphs can legitimately begin with lowercase letters when the
+    // author intentionally continues a thought without capitalization. Respect the manual
+    // line break and treat the current line as a new paragraph even when lowercase-led.
+    return true;
 }
 
 /**

--- a/js/core/chunking.js
+++ b/js/core/chunking.js
@@ -271,20 +271,15 @@ function splitIntoWordsPreservingPunctuation(textString) {
     /** @type {string[]} */
     const wordsArray = [];
     let currentWord = "";
-    let insideQuote = false;
 
     for (let index = 0; index < normalizedText.length; index += 1) {
         const character = normalizedText[index];
-        if (character === " " && !insideQuote) {
+        if (character === " ") {
             if (currentWord.length > 0) {
                 wordsArray.push(currentWord);
                 currentWord = "";
             }
             continue;
-        }
-
-        if (character === '"') {
-            insideQuote = !insideQuote;
         }
 
         currentWord += character;
@@ -308,11 +303,18 @@ function isSentenceEnd(word, nextWord, currentSentenceLength) {
         return false;
     }
 
+    const nextToken = typeof nextWord === "string" ? nextWord : "";
+    const trimmedNextToken = nextToken.trim();
+    const nextLead = getFirstSignificantCharacter(trimmedNextToken);
+
     if (!SENTENCE_TERMINATOR_PATTERN.test(strippedWord)) {
         return false;
     }
 
     if (ELLIPSIS_PATTERN.test(strippedWord)) {
+        if (nextLead.length > 0 && nextLead.toLowerCase() === nextLead) {
+            return false;
+        }
         return true;
     }
 
@@ -330,10 +332,11 @@ function isSentenceEnd(word, nextWord, currentSentenceLength) {
     }
 
     if (abbreviationType === "flexible") {
-        const nextToken = typeof nextWord === "string" ? nextWord : "";
-        const nextLead = getFirstSignificantCharacter(nextToken.trim());
         if (nextLead.length === 0) {
             return true;
+        }
+        if (/\d/.test(nextLead)) {
+            return false;
         }
         if (/[a-z]/i.test(nextLead)) {
             if (nextLead.toLowerCase() === nextLead) {
@@ -344,7 +347,11 @@ function isSentenceEnd(word, nextWord, currentSentenceLength) {
         return true;
     }
 
-    if (typeof nextWord === "string" && nextWord.trim().length === 0) {
+    if (/^[A-Z][a-z]+\.$/.test(strippedWord) && /\d/.test(nextLead)) {
+        return false;
+    }
+
+    if (typeof nextWord === "string" && trimmedNextToken.length === 0) {
         return true;
     }
 

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -206,6 +206,7 @@ export class InputPanel {
      */
     getDocumentSnapshot() {
         const clonedEditor = /** @type {HTMLDivElement} */ (this.editorElement.cloneNode(true));
+        clonedEditor.removeAttribute("id");
         const imageRecords = [];
         const imageElements = Array.from(clonedEditor.querySelectorAll("img"));
 

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -238,11 +238,15 @@ export class InputPanel {
         } finally {
             measurementContainer.remove();
         }
-        const trimmedPlaceholderText = normalizedPlaceholderText.replace(/\n{3,}/g, "\n\n").trim();
-        const plainText = richTextHelpers.extractPlainText(trimmedPlaceholderText, imageRecords);
+        const condensedBreaks = normalizedPlaceholderText.replace(/\n{3,}/g, "\n\n");
+        const hasSubstantiveContent = condensedBreaks.trim().length > 0;
+        const preparedPlaceholderText = hasSubstantiveContent
+            ? condensedBreaks.replace(/^[^\S\n]+/, "").replace(/[^\S\n]+$/, "")
+            : "";
+        const plainText = richTextHelpers.extractPlainText(preparedPlaceholderText, imageRecords);
 
         return {
-            placeholderText: trimmedPlaceholderText,
+            placeholderText: preparedPlaceholderText,
             plainText,
             images: imageRecords
         };

--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -221,13 +221,23 @@ export class InputPanel {
 
         sanitizeSnapshotTree(clonedEditor);
 
-        const inertDocument = document.implementation.createHTMLDocument("input-snapshot");
-        const inertEditor = /** @type {HTMLDivElement} */ (inertDocument.importNode(clonedEditor, true));
-        inertDocument.body.appendChild(inertEditor);
+        const measurementContainer = document.createElement("div");
+        measurementContainer.style.position = "fixed";
+        measurementContainer.style.opacity = "0";
+        measurementContainer.style.pointerEvents = "none";
+        measurementContainer.style.whiteSpace = "pre-wrap";
+        measurementContainer.style.maxWidth = "100%";
+        measurementContainer.appendChild(clonedEditor);
+        document.body.appendChild(measurementContainer);
 
-        const normalizedPlaceholderText = inertEditor.innerText
-            .replace(/\u00A0/g, " ")
-            .replace(/\r\n/g, "\n");
+        let normalizedPlaceholderText = "";
+        try {
+            normalizedPlaceholderText = clonedEditor.innerText
+                .replace(/\u00A0/g, " ")
+                .replace(/\r\n/g, "\n");
+        } finally {
+            measurementContainer.remove();
+        }
         const trimmedPlaceholderText = normalizedPlaceholderText.replace(/\n{3,}/g, "\n\n").trim();
         const plainText = richTextHelpers.extractPlainText(trimmedPlaceholderText, imageRecords);
 

--- a/tests/chunking.test.js
+++ b/tests/chunking.test.js
@@ -6,6 +6,14 @@
 import { chunkingService } from "../js/core/chunking.js";
 import { assertDeepEqual, assertEqual } from "./assert.js";
 
+const STATISTICS_SAMPLE_TEXT = Object.freeze({
+    lowercaseParagraphs: [
+        "Paragraph #1.",
+        "paragraph #2.",
+        "paragraph #3."
+    ].join("\n")
+});
+
 /**
  * Executes chunking unit tests.
  * @param {(name: string, fn: () => (void | Promise<void>)) => Promise<void>} runTest Test harness callback.
@@ -223,6 +231,16 @@ export async function runChunkingTests(runTest) {
                 words: 5,
                 sentences: 3,
                 paragraphs: 1
+            }
+        },
+        {
+            name: "treats lowercase-leading paragraphs as distinct entries",
+            input: STATISTICS_SAMPLE_TEXT.lowercaseParagraphs,
+            expected: {
+                characters: STATISTICS_SAMPLE_TEXT.lowercaseParagraphs.length,
+                words: 6,
+                sentences: 3,
+                paragraphs: 3
             }
         }
     ];

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -407,7 +407,7 @@ export async function runIntegrationTests(runTest) {
                                 { children: ["Words wrong everywhere."] }
                             ],
                             false,
-                            { characters: 59, words: 7, sentences: 3, paragraphs: 2 }
+                            { characters: 58, words: 7, sentences: 3, paragraphs: 2 }
                         ),
                         createParagraphStatisticsFixture(
                             "abbreviations and decimals do not inflate statistics",
@@ -429,7 +429,7 @@ export async function runIntegrationTests(runTest) {
                                 }
                             ],
                             false,
-                            { characters: 176, words: 29, sentences: 4, paragraphs: 3 }
+                            { characters: 174, words: 29, sentences: 4, paragraphs: 3 }
                         ),
                         createParagraphStatisticsFixture(
                             "single paragraph keeps toggle disabled",

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -197,6 +197,25 @@ function createParagraphStatisticsFixture(
     };
 }
 
+const LOWERCASE_PARAGRAPH_SAMPLE = Object.freeze({
+    first: "Paragraph #1.",
+    second: "paragraph #2.",
+    third: "paragraph #3."
+});
+
+const LOWERCASE_PARAGRAPH_JOINED = [
+    LOWERCASE_PARAGRAPH_SAMPLE.first,
+    LOWERCASE_PARAGRAPH_SAMPLE.second,
+    LOWERCASE_PARAGRAPH_SAMPLE.third
+].join("\n");
+
+const LOWERCASE_PARAGRAPH_EXPECTED_STATISTICS = Object.freeze({
+    characters: LOWERCASE_PARAGRAPH_JOINED.length,
+    words: 6,
+    sentences: 3,
+    paragraphs: 3
+});
+
 /**
  * Sets up a minimal DOM fixture and controller instance for integration testing.
  * @returns {{ elements: Record<string, HTMLElement>, cleanup: () => void }}
@@ -455,6 +474,16 @@ export async function runIntegrationTests(runTest) {
                             ],
                             false,
                             { characters: 41, words: 6, sentences: 3, paragraphs: 3 }
+                        ),
+                        createParagraphStatisticsFixture(
+                            "lowercase-leading paragraphs collapse into one block",
+                            [
+                                { children: [LOWERCASE_PARAGRAPH_SAMPLE.first] },
+                                { children: [LOWERCASE_PARAGRAPH_SAMPLE.second] },
+                                { children: [LOWERCASE_PARAGRAPH_SAMPLE.third] }
+                            ],
+                            false,
+                            LOWERCASE_PARAGRAPH_EXPECTED_STATISTICS
                         ),
                         createParagraphStatisticsFixture(
                             "trailing blank paragraph is ignored",


### PR DESCRIPTION
## Summary
- ensure paragraph snapshots read innerText from a temporary measured clone so newline structure survives statistics calculations
- refine word and sentence heuristics to handle quoted phrases, abbreviations, ellipses, and month-day patterns without inflating counts
- update multi-paragraph integration fixtures to match real editor serialization

## Testing
- `npm run test:headless`
- `npm run test:browser` *(fails: Puppeteer missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6136fd03883278ae7587fe91bfe3e