### PR TITLE
Handle missing Node constructor in document snapshot

### DIFF
--- a/js/ui/inputPanel.js
+++ b/js/ui/inputPanel.js
@@ -265,18 +265,23 @@ export class InputPanel {
         inertDocument.body.appendChild(inertEditor);
 
         const inertChildNodes = Array.from(inertEditor.childNodes);
-        const sampleNodeForNodeType = inertChildNodes[0] ?? inertEditor;
-        const windowNodeConstructor = typeof window === "undefined" ? undefined : window.Node;
-        const nodeConstructor =
-            sampleNodeForNodeType.ownerDocument?.defaultView?.Node ?? windowNodeConstructor;
-        const resolvedTextNodeType =
-            typeof nodeConstructor === "undefined" || nodeConstructor === null
-                ? 3
-                : nodeConstructor.TEXT_NODE;
-        const resolvedElementNodeType =
-            typeof nodeConstructor === "undefined" || nodeConstructor === null
-                ? 1
-                : nodeConstructor.ELEMENT_NODE;
+        const fallbackNodeConstructor = typeof window === "undefined" ? undefined : window.Node;
+        /** @type {{ text: number; element: number } | null} */
+        let resolvedNodeTypeValues = null;
+        inertChildNodes.some((childNode) => {
+            const nodeConstructor =
+                childNode.ownerDocument?.defaultView?.Node ?? fallbackNodeConstructor;
+            if (typeof nodeConstructor === "undefined" || nodeConstructor === null) {
+                return false;
+            }
+            resolvedNodeTypeValues = {
+                text: nodeConstructor.TEXT_NODE,
+                element: nodeConstructor.ELEMENT_NODE
+            };
+            return true;
+        });
+        const resolvedTextNodeType = resolvedNodeTypeValues?.text ?? 3;
+        const resolvedElementNodeType = resolvedNodeTypeValues?.element ?? 1;
 
         /** @type {(string | symbol)[]} */
         const placeholderSegments = [];

--- a/tests/inputPanel.test.js
+++ b/tests/inputPanel.test.js
@@ -13,7 +13,8 @@ const SNAPSHOT_ASSERTION_MESSAGES = Object.freeze({
     plainTextMismatch: "Snapshot plain text should match expected newline separated paragraphs",
     serializedLengthMismatch: "Serialized placeholder text should match the expected character length",
     plainTextLengthMismatch: "Snapshot plain text should match the expected character length",
-    statisticsTextMismatch: "Statistics summary should match expected template output when Node constructor is removed"
+    statisticsTextMismatch:
+        "Statistics summary should match expected template output when globalThis.Node constructor is removed"
 });
 
 const PARAGRAPH_TEXT_CONTENT = Object.freeze({
@@ -260,7 +261,7 @@ const DOCUMENT_CASES = [
         ]
     },
     {
-        name: "captures text and statistics when Node constructor is removed",
+        name: "captures text and statistics when globalThis.Node constructor is removed",
         expectedText: EXPECTED_SNAPSHOT_TEXT.sequentialParagraphs,
         builderSteps: SEQUENTIAL_PARAGRAPH_BUILDER_STEPS,
         prepareEnvironment: () => {


### PR DESCRIPTION
## Plan
- Resolve node-type constants by reading each child node's window constructor before falling back to numeric defaults.
- Update traversal logic to reuse cached node-type constants.
- Extend the document snapshot tests to cover scenarios where `globalThis.Node` is temporarily removed.

## Summary
- Cache the first available `Node` constructor from inert editor children with numeric fallbacks during snapshot serialization.
- Reuse the cached node-type values for text and element comparisons inside the traversal.
- Clarify the snapshot regression test messaging for the `globalThis.Node` removal scenario.

## Testing
- `npm test` *(fails: Puppeteer requires libatk-1.0.so.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d86dda70648327b090f50c0b461b25