### PR TITLE
Handle unsupported image clipboard copy

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -266,6 +266,25 @@ button:hover {
     cursor: default;
 }
 
+.copyButton.error {
+    background-color: #dc3545;
+    cursor: not-allowed;
+}
+
+.copyButton.error:hover {
+    background-color: #c82333;
+}
+
+.chunkContainer.copyError::before {
+    content: "!";
+    background-color: #dc3545;
+    color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: bold;
+}
+
 .chunkContainer.copied::before {
     content: attr(data-copied-order);
     background-color: #28a745;

--- a/js/constants.js
+++ b/js/constants.js
@@ -14,6 +14,7 @@ export const TEXT_CONTENT = Object.freeze({
     CUSTOM_BUTTON_TEMPLATE: "Custom ({VALUE})",
     COPY_BUTTON_LABEL: "Copy",
     COPY_BUTTON_SUCCESS_LABEL: "Copied!",
+    COPY_BUTTON_IMAGE_UNSUPPORTED_LABEL: "Browser cannot copy images",
     PASTED_IMAGE_ALT: "Pasted image",
     IMAGE_PLAIN_TEXT_PLACEHOLDER: "[Image]",
     ERROR_NO_TEXT: "Please enter some text to split.",
@@ -34,6 +35,7 @@ export const TEXT_CONTENT = Object.freeze({
 /** @type {Readonly<Record<string, string>>} */
 export const LOG_MESSAGES = Object.freeze({
     COPY_FAILURE: "Failed to copy chunk to clipboard",
+    IMAGE_COPY_UNSUPPORTED: "Clipboard does not support copying image chunks",
     CLIPBOARD_UNAVAILABLE: "Clipboard API is not available",
     IMAGE_READ_FAILURE: "Unable to read file as data URL",
     IMAGE_READ_ERROR: "Failed to read file",

--- a/js/ui/chunkListView.js
+++ b/js/ui/chunkListView.js
@@ -124,4 +124,20 @@ export class ChunkListView {
             buttonElement.disabled = false;
         }, 2000);
     }
+
+    /**
+     * Marks a chunk as having encountered a copy error.
+     * @param {HTMLDivElement} containerElement Container representing the chunk.
+     * @param {HTMLButtonElement} buttonElement Button element used to trigger the copy action.
+     * @returns {void}
+     */
+    markChunkCopyError(containerElement, buttonElement) {
+        containerElement.removeAttribute("data-copied-order");
+        containerElement.classList.remove("copied");
+        containerElement.classList.add("copyError");
+        buttonElement.textContent = TEXT_CONTENT.COPY_BUTTON_IMAGE_UNSUPPORTED_LABEL;
+        buttonElement.classList.remove("success");
+        buttonElement.classList.add("error");
+        buttonElement.disabled = true;
+    }
 }


### PR DESCRIPTION
## Summary
- surface a descriptive error when image chunks cannot use rich clipboard support and avoid falling back to empty plain-text copies
- add chunk list error styling so unsupported image copies disable the button and show the browser limitation
- refactor integration helpers for deterministic image pastes and add a regression test covering browsers without ClipboardItem

## Testing
- npm run test:headless
- npm run test:browser *(fails: Chromium launch error - missing libatk-1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dae75489f483279ba3a7c19000b645