### PR TITLE
Ensure Safari uses sans-serif fonts in editors

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -10,7 +10,7 @@ body {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     background-color: #fff;
     color: #000;
 }
@@ -48,7 +48,7 @@ body {
     width: 100%;
     padding: 10px;
     font-size: 14px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     resize: none;
     border: 1px solid #ccc;
     border-radius: 4px;
@@ -219,7 +219,7 @@ button:hover {
 
 .chunkContainer .chunkContent {
     width: 100%;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     font-size: 14px;
     padding: 10px;
     border: 1px solid #ccc;
@@ -229,6 +229,11 @@ button:hover {
     white-space: pre-wrap;
     word-wrap: break-word;
     min-height: 40px;
+}
+
+.left-pane .richTextInput *,
+.chunkContainer .chunkContent * {
+    font-family: inherit !important;
 }
 
 .chunkContainer .chunkContent img {


### PR DESCRIPTION
## Summary
- expand the global, editor, and chunk font stacks to a modern system UI set
- enforce inherited fonts on rich text descendants to prevent Safari from injecting serif spans

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68daf52fa6c48327a35cb59099742db5