### PR TITLE
Improve Safari image clipboard handling

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -140,9 +140,28 @@ export const HTML_TEMPLATES = Object.freeze({
 });
 
 /** @type {Readonly<Record<string, string>>} */
+export const CLIPBOARD_PRESENTATION_STYLES = Object.freeze({
+    ATTACHMENT: "attachment"
+});
+
+/** @type {Readonly<Record<string, string>>} */
 export const PLACEHOLDER_TOKENS = Object.freeze({
     IMAGE_PREFIX: "[[IMAGE:",
     IMAGE_SUFFIX: "]]"
+});
+
+/** @type {Readonly<Record<string, string>>} */
+export const USER_AGENT_TOKENS = Object.freeze({
+    SAFARI: "Safari",
+    CHROME: "Chrome",
+    CHROMIUM: "Chromium",
+    IOS_CHROME: "CriOS",
+    IOS_FIREFOX: "FxiOS"
+});
+
+/** @type {Readonly<Record<string, string>>} */
+export const NAVIGATOR_VENDOR_VALUES = Object.freeze({
+    APPLE: "Apple Computer, Inc."
 });
 
 export const TEST_MODE_CONFIG = Object.freeze({


### PR DESCRIPTION
## Summary
- add browser identity constants to drive Safari clipboard detection
- update the clipboard controller to use attachment-style ClipboardItem payloads for Safari image variants while preserving HTML for other browsers
- extend the integration suite to verify the new Safari attachment path, record ClipboardItem constructor options, and ensure binary image blobs remain intact

## Testing
- npm run test:headless (pass)
- npm run test:browser (fails: Puppeteer missing libatk-1.0.so.0 in container)


------
https://chatgpt.com/codex/tasks/task_e_68db0421bca08327845900a3fc1b85bf